### PR TITLE
Sort export without args

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/21 02:47:32 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/09/21 03:52:15 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -138,7 +138,7 @@ int			solve_param(t_shell *shell, t_seg *param, t_expand *build);
 int			expand_redir(t_shell *shell, t_redir *redir);
 int			expand_redirs(t_shell *shell, t_redirs *redirs);
 
-int			minheap_new_push(t_list **heap, char *todup);
+int			minsortedlst_new_push(t_list **lst, char *todup);
 
 int			expand_wildcards(t_shell *shell, t_builder *builder, t_argv *argv);
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/21 03:52:15 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/09/21 04:39:12 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -183,7 +183,8 @@ int			ft_echo(t_cmd *cmd);
 int			ft_exit(t_shell *shell, char *argv[]);
 int			ft_export(t_shell *shell, char **argv);
 
-void		export_print_error(t_shell *shell, char *arg);
+void		export_perror_identifier(t_shell *shell, char *argv);
+
 int			export_print_all(t_shell *shell);
 
 

--- a/source/builtins/export.c
+++ b/source/builtins/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gomandam <gomandam@student.42.fr>          +#+  +:+       +#+        */
+/*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/21 01:16:30 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/09/21 04:38:04 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,7 @@ static int	export_one(t_shell *shell, const char *arg)
 	char	*full;
 
 	if (!export_key_valid(arg))
-		return (export_print_error(shell, (char *)arg), 1);
+		return (export_perror_identifier(shell, (char *)arg), 1);
 	eq = ft_strchr(arg, '=');
 	val = NULL;
 	if (eq != NULL)

--- a/source/expansion/wildcards.c
+++ b/source/expansion/wildcards.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/16 12:08:36 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/15 22:57:38 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/09/21 03:52:46 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ int	start_wildcard(t_builder *builder, t_atom **start, size_t *offset)
 	return (0);
 }
 
-int	wildcard_solve(t_shell *shell, t_builder *builder, t_list **heap_wildcard)
+int	wildcard_solve(t_shell *shell, t_builder *builder, t_list **lst_wildcard)
 {
 	DIR				*cur;
 	struct dirent	*entry;
@@ -99,7 +99,7 @@ int	wildcard_solve(t_shell *shell, t_builder *builder, t_list **heap_wildcard)
 	{
 		if (wildcard_match(entry->d_name, &start, &offset) == 1)
 		{
-			if (minheap_new_push(heap_wildcard, entry->d_name) == 1)
+			if (minsortedlst_new_push(lst_wildcard, entry->d_name) == 1)
 				return (perror_malloc(shell), closedir(cur), 1);
 		}
 		entry = readdir(cur);

--- a/source/expansion/wildcards2.c
+++ b/source/expansion/wildcards2.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/15 22:07:18 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/15 22:59:43 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/09/21 03:51:47 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ t_list	*new_list_node_dup(char *todup)
 	return (new_node);
 }
 
-int	minheap_new_push(t_list **heap, char *todup)
+int	minsortedlst_new_push(t_list **lst, char *todup)
 {
 	t_list	*new_node;
 	t_list	*cur;
@@ -34,14 +34,14 @@ int	minheap_new_push(t_list **heap, char *todup)
 	new_node = new_list_node_dup(todup);
 	if (new_node == NULL)
 		return (1);
-	if (*heap == NULL || ft_strcmp(new_node->content, (*heap)->content) < 0)
+	if (*lst == NULL || ft_strcmp(new_node->content, (*lst)->content) < 0)
 	{
-		new_node->next = *heap;
-		*heap = new_node;
+		new_node->next = *lst;
+		*lst = new_node;
 	}
 	else
 	{
-		cur = *heap;
+		cur = *lst;
 		while (cur->next != NULL
 			&& ft_strcmp(new_node->content, cur->next->content) >= 0)
 			cur = cur->next;


### PR DESCRIPTION
Export buil-in without args is now sorted using ft_strncmp. This PR solves last point in the issue #12 
