### PR TITLE
Builtins updated set_last_status

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/10/01 13:27:02 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 16:55:20 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -192,7 +192,7 @@ int			init_shell(t_shell *shell, char *envp[]);
 
 // builtins
 int			ft_pwd(void);
-int			ft_env(t_env_list *env_list);
+int			ft_env(t_shell *shell);
 int			ft_unset(t_shell *shell, char *argv[]);
 int			ft_echo(t_shell *shell, t_cmd *cmd);
 int			ft_exit(t_shell *shell, char *argv[]);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/29 19:03:52 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 13:27:02 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -194,7 +194,7 @@ int			init_shell(t_shell *shell, char *envp[]);
 int			ft_pwd(void);
 int			ft_env(t_env_list *env_list);
 int			ft_unset(t_shell *shell, char *argv[]);
-int			ft_echo(t_cmd *cmd);
+int			ft_echo(t_shell *shell, t_cmd *cmd);
 int			ft_exit(t_shell *shell, char *argv[]);
 int			ft_export(t_shell *shell, char **argv);
 int			ft_cd(t_shell *shell, char **argv);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/10/01 16:55:20 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 19:58:15 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -191,7 +191,7 @@ void		free_env_list(t_env_list *env_list);
 int			init_shell(t_shell *shell, char *envp[]);
 
 // builtins
-int			ft_pwd(void);
+int			ft_pwd(t_shell *shell);
 int			ft_env(t_shell *shell);
 int			ft_unset(t_shell *shell, char *argv[]);
 int			ft_echo(t_shell *shell, t_cmd *cmd);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/10/01 19:58:15 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:33:49 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -198,8 +198,6 @@ int			ft_echo(t_shell *shell, t_cmd *cmd);
 int			ft_exit(t_shell *shell, char *argv[]);
 int			ft_export(t_shell *shell, char **argv);
 int			ft_cd(t_shell *shell, char **argv);
-
-void		export_perror_identifier(t_shell *shell, char *argv);
 
 int			export_print_all(t_shell *shell);
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/20 00:02:21 by migugar2          #+#    #+#             */
-/*   Updated: 2025/10/01 21:33:49 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 22:20:41 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,8 @@
 # include <termios.h> // tcgetattr, tcsetattr
 # include <termcap.h>
 // tgetent, tgetflag, tgetnum, tgetstr, tgoto, tputs
+
+# include <limits.h> // LLONG_MAX, LLONG_MIN
 
 # define MINI_PROMPT "MINI> $ " // TODO
 # define HEREDOC_PROMPT "> " // TODO

--- a/source/builtins/echo.c
+++ b/source/builtins/echo.c
@@ -6,7 +6,7 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:14 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 13:45:36 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 20:48:20 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,7 @@ static void	echo_last_status(t_shell *shell, int error)
 		set_last_status(shell, 1);
 	else
 		set_last_status(shell, 0);
-}		
+}
 
 int	ft_echo(t_shell *shell, t_cmd *cmd)
 {
@@ -83,7 +83,8 @@ int	ft_echo(t_shell *shell, t_cmd *cmd)
 	echo_last_status(shell, error);
 	return (error);
 }
-// Same as Nested IF: if (!n_flag && !error && write(STDOUT_FILENO, "\n", 1) == -1)
+// Same as Nested IF:
+// 	if (!n_flag && !error && write(STDOUT_FILENO, "\n", 1) == -1)
 // Test: echo -n foo > /dev/full   **output:  write error, space on device**
 /* test: tokens, output redir (STDOUT)
 echo foo bar			foo bar		0

--- a/source/builtins/env.c
+++ b/source/builtins/env.c
@@ -6,30 +6,80 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:25 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/11 02:17:57 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 17:14:12 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-// protoyped: char *envp[] or struct state t_shell *shell
+// Changed to struct state t_shell *shell -> access set_last_status()
 #include "../../include/minishell.h"
+#include "../../libft/libft.h"
 
-int	ft_env(t_env_list *env_list)
+// ft_putendl_fd() reference
+static int	ft_putendl_check(char *s, int fd)
 {
-	t_env	*current;
-
-	current = env_list->head;
-	while (current)
-	{
-		if (current->full && ft_strchr(current->full, '='))
-			printf("%s\n", current->full);
-		current = current->next;
-	}
+	int	len;
+	int	written;
+	
+	if (s == NULL)
+		return (0);
+	len = 0;
+	while (s[len])
+		len++;
+	written = write(fd, s, len);
+	if (written != len )
+		return (1);
+	written = write(fd, "\n", 1);
+	if (written != 1)
+		return (1);
 	return (0);
 }
 
+static void	env_set_status(t_shell *shell, int error)
+{
+	if (error)
+		set_last_status(shell, 1);
+	else
+		set_last_status(shell, 0);
+}
+
+int	ft_env(t_shell *shell)
+{
+	t_env	*current;
+	int	error;
+
+	current = shell->env_list.head;
+	error = 0;
+	while (current)
+	{
+		if (current->full && ft_strchr(current->full, '='))
+			if (ft_putendl_check(current->full, STDOUT_FILENO))
+				error = 1;
+		current = current->next;
+	}
+	env_set_status(shell, error);
+	return (error);
+}
+
 /*
-	env - lists environmental variables outputs KEY=VALUE by child-process
+	env - lists environmental variables outputs KEY=VALUE
 	stores info used by processes (e.g. PATH, HOME, USER)
 	each string has "=" so validate on this
 	read (RTFM!) -> man 3 getenv
+*/
+/* TESTS
+env -i
+
+env foo bar
+
+env | head -n 3    or | tail -n 3
+
+env | cat
+
+env | (exit 1)
+
+env > /dev/null
+env > test.txt
+env > /dev/full
+env > .
+
 */

--- a/source/builtins/env.c
+++ b/source/builtins/env.c
@@ -6,7 +6,7 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:25 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 17:14:12 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:36:46 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,14 +19,14 @@ static int	ft_putendl_check(char *s, int fd)
 {
 	int	len;
 	int	written;
-	
+
 	if (s == NULL)
 		return (0);
 	len = 0;
 	while (s[len])
 		len++;
 	written = write(fd, s, len);
-	if (written != len )
+	if (written != len)
 		return (1);
 	written = write(fd, "\n", 1);
 	if (written != 1)
@@ -45,7 +45,7 @@ static void	env_set_status(t_shell *shell, int error)
 int	ft_env(t_shell *shell)
 {
 	t_env	*current;
-	int	error;
+	int		error;
 
 	current = shell->env_list.head;
 	error = 0;

--- a/source/builtins/exit.c
+++ b/source/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:44 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/11 23:18:46 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:54:52 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,10 +44,9 @@ static int	is_numeric(const char *str)
 	}
 	return (1);
 }
-//! 	string to long long (ft_strtoll) => check this functions
 //	Converts string to long long
 
-static long long	ft_strtoll(const char *str)
+static long long	ft_atoll(const char *str)
 {
 	long long	res;
 	int			sign;
@@ -105,7 +104,7 @@ int	ft_exit(t_shell *shell, char *argv[])
 		return (1);
 	}
 	else
-		status = ft_strtoll(argv[1]);
+		status = ft_atoll(argv[1]);
 	status = (uint8_t)status;
 	rl_clear_history();
 	free_shell(shell);

--- a/source/builtins/exit.c
+++ b/source/builtins/exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
+/*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:44 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 21:54:52 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 22:23:37 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,10 @@ static void	free_shell(t_shell *shell)
 	if (!shell)
 		return ;
 	if (shell->line)
-		free(shell->line);
+		ft_freestr(&shell->line);
+	rl_clear_history();
 	if (shell->ast)
-		free_exp_ast(&shell->ast);
+		free_exp_ast(&shell->ast); // TODO: free current as exp, rest as parse
 	free_env_list(&shell->env_list);
 }
 
@@ -44,9 +45,18 @@ static int	is_numeric(const char *str)
 	}
 	return (1);
 }
-//	Converts string to long long
 
-static long long	ft_atoll(const char *str)
+static int	exit_perror_numeric(t_shell *shell, const char *argv)
+{
+	ft_putstr_fd("minishell: exit: ", 2);
+	ft_putstr_fd((char *)argv, 2);
+	ft_putstr_fd(": numeric argument required\n", 2);
+	free_shell(shell);
+	exit(2);
+	return (1);
+}
+
+static long long	exit_to_ll(t_shell *shell, const char *str)
 {
 	long long	res;
 	int			sign;
@@ -65,19 +75,14 @@ static long long	ft_atoll(const char *str)
 	}
 	while (str[i] >= '0' && str[i] <= '9')
 	{
+		if (sign == 1 && (res > (LLONG_MAX - (str[i] - '0')) / 10))
+			exit_perror_numeric(shell, str);
+		else if (sign == -1 && (-res < (LLONG_MIN + (str[i] - '0')) / 10))
+			exit_perror_numeric(shell, str);
 		res = res * 10 + (str[i] - '0');
 		i++;
 	}
 	return (res * sign);
-}
-
-static void	perror_numeric(t_shell *shell, const char *argv)
-{
-	ft_putstr_fd("minishell: exit: ", 2);
-	ft_putstr_fd((char *)argv, 2);
-	ft_putstr_fd(": numeric argument required\n", 2);
-	free_shell(shell);
-	exit(2);
 }
 
 /*	print "exit" before executing exit
@@ -89,14 +94,14 @@ static void	perror_numeric(t_shell *shell, const char *argv)
 */
 int	ft_exit(t_shell *shell, char *argv[])
 {
-	long long	status;
+	uint8_t	status;
 
 	status = 0;
-	write(1, "exit\n", 5);
+	write(2, "exit\n", 5);
 	if (!argv[1])
 		status = shell->last_status;
 	else if (!is_numeric(argv[1]))
-		perror_numeric(shell, argv[1]);
+		exit_perror_numeric(shell, argv[1]);
 	else if (argv[2])
 	{
 		ft_putstr_fd("minishell: exit: too many arguments\n", 2);
@@ -104,9 +109,7 @@ int	ft_exit(t_shell *shell, char *argv[])
 		return (1);
 	}
 	else
-		status = ft_atoll(argv[1]);
-	status = (uint8_t)status;
-	rl_clear_history();
+		status = (uint8_t)exit_to_ll(shell, argv[1]);
 	free_shell(shell);
 	exit(status);
 }

--- a/source/builtins/export.c
+++ b/source/builtins/export.c
@@ -6,12 +6,20 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 21:16:17 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:32:57 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 #include "../../libft/libft.h"
+
+static void	export_perror_identifier(t_shell *shell, char *argv)
+{
+	ft_putstr_fd("minishell: export: '", 2);
+	ft_putstr_fd(argv, 2);
+	ft_putstr_fd("': not a valid identifier\n", 2);
+	set_last_status(shell, 1);
+}
 
 static int	env_update_move(t_env_list *env_list, t_env *found, t_env *prev)
 {

--- a/source/builtins/export.c
+++ b/source/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/29 19:05:58 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:16:17 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,21 +86,17 @@ static int	is_key_valid(const char *s)
    Returns 0 success, 1 if any error. */
 int	ft_export(t_shell *shell, char **argv)
 {
-	int		any_err;
 	int		i;
 	char	*val;
 
 	if (!argv || !argv[1])
 		return (export_print_all(shell), 0);
 	i = 1;
-	any_err = 0;
+	set_last_status(shell, 0);
 	while (argv[i])
 	{
 		if (!is_key_valid(argv[i]))
-		{
 			export_perror_identifier(shell, argv[i]);
-			any_err = 1;
-		}
 		else
 		{
 			val = ft_strchr(argv[i], '=');
@@ -112,5 +108,5 @@ int	ft_export(t_shell *shell, char **argv)
 		}
 		i++;
 	}
-	return (any_err);
+	return (0);
 }

--- a/source/builtins/export2.c
+++ b/source/builtins/export2.c
@@ -6,20 +6,12 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/24 02:20:57 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:32:31 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 #include "../../libft/libft.h"
-
-void	export_perror_identifier(t_shell *shell, char *argv)
-{
-	ft_putstr_fd("minishell: export: '", 2);
-	ft_putstr_fd(argv, 2);
-	ft_putstr_fd("': not a valid identifier\n", 2);
-	set_last_status(shell, 1);
-}
 
 static int	cmp_exportkey(const char *s1, const char *s2, size_t eq_s1)
 {

--- a/source/builtins/pwd.c
+++ b/source/builtins/pwd.c
@@ -6,29 +6,58 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:55 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/27 18:43:31 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 20:01:34 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/minishell.h"
 #include "../../libft/libft.h"
-/*
-** print working directory | current working directory
-** Prints the current working directory to stdout.
-** Returns 0 on success, 1 on failure.
-	No need for t_shell args since !modify/read session state
-*/
-int	ft_pwd(void)
+
+// Hola Angel, I did the same as env because it is easier to understand.
+// We can just make it as one function, and declare it. But I was thinking,
+// just in case you want to modify it. It is easier this way, correct?
+
+static int      ft_putendl_check(char *s, int fd)
+{
+        int     len;
+        int     written;
+
+        if (s == NULL)
+                return (0);
+        len = 0;
+        while (s[len])
+                len++;
+        written = write(fd, s, len);
+        if (written != len )
+                return (1);
+        written = write(fd, "\n", 1);
+        if (written != 1)
+                return (1);
+        return (0);
+}
+
+static void	pwd_set_status(t_shell *shell, int error)
+{
+	if (error)
+		set_last_status(shell, 1);
+	else
+		set_last_status(shell, 0);
+}
+
+int	ft_pwd(t_shell *shell)
 {
 	char	*cwd;
+	int		error;
 
 	cwd = getcwd(NULL, 0);
+	error = 0;
 	if (cwd == NULL)
 	{
 		perror("minishell: pwd: error retrieving current directory");
-		return (1);
+		return (pwd_set_status(shell, 1), 1);
 	}
-	printf("%s\n", cwd);
+	error = ft_putendl_check(cwd, 1);
+	pwd_set_status(shell, error);
 	free(cwd);
-	return (0);
+	return (error);
 }

--- a/source/builtins/pwd.c
+++ b/source/builtins/pwd.c
@@ -6,7 +6,7 @@
 /*   By: gomandam <gomandam@student.42madrid>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:03:55 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 20:01:34 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 20:46:34 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,23 +17,23 @@
 // We can just make it as one function, and declare it. But I was thinking,
 // just in case you want to modify it. It is easier this way, correct?
 
-static int      ft_putendl_check(char *s, int fd)
+static int	ft_putendl_check(char *s, int fd)
 {
-        int     len;
-        int     written;
+	int	len;
+	int	written;
 
-        if (s == NULL)
-                return (0);
-        len = 0;
-        while (s[len])
-                len++;
-        written = write(fd, s, len);
-        if (written != len )
-                return (1);
-        written = write(fd, "\n", 1);
-        if (written != 1)
-                return (1);
-        return (0);
+	if (s == NULL)
+		return (0);
+	len = 0;
+	while (s[len])
+		len++;
+	written = write(fd, s, len);
+	if (written != len)
+		return (1);
+	written = write(fd, "\n", 1);
+	if (written != 1)
+		return (1);
+	return (0);
 }
 
 static void	pwd_set_status(t_shell *shell, int error)

--- a/source/builtins/unset.c
+++ b/source/builtins/unset.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/26 03:37:52 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:12:28 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,81 @@
 #include "../../include/minishell.h"
 #include "../../libft/libft.h"
 
+// OLD refactor of unset -> re-implemented again
+static int	is_valid_identifier(const char *s)
+{
+	int	i;
+
+	if (!s || !(ft_isalpha(s[0]) || s[0] == '_'))
+		return (0);
+	i = 1;
+	while (s[i])
+	{
+		if (!(ft_isalnum(s[i]) || s[i] == '_'))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+static void	unset_error_msg(const char *arg)
+{
+	ft_putstr_fd("minishell: unset: '", 2);
+	ft_putstr_fd((char *)arg, 2);
+	ft_putstr_fd("': not a valid identifier\n", 2);
+}
+
+int	ft_unset(t_shell *shell, char *argv[])
+{
+	int		i;
+	int		error;
+
+	if (!argv || !argv[1])
+		return (set_last_status(shell, 0), 0);
+	i = 1;
+	error = 0;
+	while (argv[i])
+	{
+		if (!is_valid_identifier(argv[i]))
+		{
+			unset_error_msg(argv[i]);
+			error = 1;
+		}
+		else
+			env_remove(&shell->env_list, argv[i], ft_strlen(argv[i]));
+		i++;
+	}
+	set_last_status(shell, error);
+	return (error);
+}
+
+/* TEST for last_status
+export MYVAR=42
+unset MYVAR
+
+export A=1 B=2
+unset A B
+
+export GOOD=ok
+unset GOOD 2BAD
+
+unset
+
+unset 1 2 3
+
+unset ""
+
+unset -f MYVAR
+
+unset DOES_NOT_EXIST
+
+unset 1INVALID
+
+unset BAD-NAME
+unset "BAD NAME"
+
+unset PATH
+*/
 // Find env node by key
 /*
 static int	find_env_node(t_env_list *env_list, const char *key,
@@ -43,11 +118,11 @@ static int	find_env_node(t_env_list *env_list, const char *key,
 	return (0);
 }
 */
-
 /*
 	unset: implements the 'unset' built-in.
 	argv[0] = "unset", argv[1..n] = var names to unset
 	Returns 1 if any variable was removed, 0 otherwise.	*/
+/*
 int	ft_unset(t_shell *shell, char *argv[])
 {
 	int		i;
@@ -65,7 +140,7 @@ int	ft_unset(t_shell *shell, char *argv[])
 	}
 	return (0);
 }
-
+*/
 /*
 int	unset(char *argv[], char *envp[])
 {

--- a/source/builtins/unset.c
+++ b/source/builtins/unset.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 02:04:11 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 21:12:28 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 21:16:20 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,10 +34,10 @@ static int	is_valid_identifier(const char *s)
 	return (1);
 }
 
-static void	unset_error_msg(const char *arg)
+static void	unset_error_msg(char *arg)
 {
 	ft_putstr_fd("minishell: unset: '", 2);
-	ft_putstr_fd((char *)arg, 2);
+	ft_putstr_fd(arg, 2);
 	ft_putstr_fd("': not a valid identifier\n", 2);
 }
 

--- a/source/execute/cmd_exec.c
+++ b/source/execute/cmd_exec.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/22 00:24:27 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 16:56:54 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 19:58:42 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,7 @@ int	run_builtin_external(t_shell *shell, t_ast **ast, pid_t *pid)
 			*pid = 0;
 		ft_putstr_fd("DEBUG: inside is_builtin() -> builtin fx\n", 2);
 		if (!ft_strcmp(cmd->u_data.argv[0], "pwd"))
-			return (ft_pwd());
+			return (ft_pwd(shell));
 		if (!ft_strcmp(cmd->u_data.argv[0], "env"))
 			return (ft_env(shell));
 		if (!ft_strcmp(cmd->u_data.argv[0], "unset"))

--- a/source/execute/cmd_exec.c
+++ b/source/execute/cmd_exec.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/22 00:24:27 by gomandam          #+#    #+#             */
-/*   Updated: 2025/09/29 19:03:47 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 13:28:11 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ int	run_builtin_external(t_shell *shell, t_ast **ast, pid_t *pid)
 		if (!ft_strcmp(cmd->u_data.argv[0], "unset"))
 			return (ft_unset(shell, cmd->u_data.argv));
 		if (!ft_strcmp(cmd->u_data.argv[0], "echo"))
-			return (ft_echo(cmd));
+			return (ft_echo(shell, cmd));
 		if (!ft_strcmp(cmd->u_data.argv[0], "exit"))
 			return (ft_exit(shell, cmd->u_data.argv));
 		if (!ft_strcmp(cmd->u_data.argv[0], "export"))

--- a/source/execute/cmd_exec.c
+++ b/source/execute/cmd_exec.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/22 00:24:27 by gomandam          #+#    #+#             */
-/*   Updated: 2025/10/01 13:28:11 by gomandam         ###   ########.fr       */
+/*   Updated: 2025/10/01 16:56:54 by gomandam         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,7 @@ int	run_builtin_external(t_shell *shell, t_ast **ast, pid_t *pid)
 		if (!ft_strcmp(cmd->u_data.argv[0], "pwd"))
 			return (ft_pwd());
 		if (!ft_strcmp(cmd->u_data.argv[0], "env"))
-			return (ft_env(&shell->env_list));
+			return (ft_env(shell));
 		if (!ft_strcmp(cmd->u_data.argv[0], "unset"))
 			return (ft_unset(shell, cmd->u_data.argv));
 		if (!ft_strcmp(cmd->u_data.argv[0], "echo"))

--- a/source/repl.c
+++ b/source/repl.c
@@ -6,7 +6,7 @@
 /*   By: migugar2 <migugar2@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/11 01:33:59 by migugar2          #+#    #+#             */
-/*   Updated: 2025/09/26 14:18:39 by migugar2         ###   ########.fr       */
+/*   Updated: 2025/10/01 22:24:06 by migugar2         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ void	clear_repl(t_shell *shell)
 	free_env_list(&shell->env_list);
 	rl_clear_history();
 	if (shell->interactive)
-		write(STDOUT_FILENO, "exit\n", 5);
+		write(STDERR_FILENO, "exit\n", 5);
 }
 
 void	set_last_status(t_shell *shell, long long status)


### PR DESCRIPTION
The minishell builtins accommodate full bash-compliant state, ensuring all edge cases, error handling, and status codes behave as expected for user tests.
- Last status and exit status handling ($?)
- Norminette and memory safe
- POSIX shell behavior

Thanks for your cooperation, and trust. All the best, Angel.
> "Progress is not in enhancing what is, but in advancing toward what will be." -Khalil Gibran